### PR TITLE
created benchmark testing for augments_fasttext function, and refactored augments_fasttext to allow for use of annoy library without fasttext model download

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,11 @@ jobs:
         #flake8 --ignore=E501,E123,E402 .
     - name: Test with pytest
       run: |
-        pytest tests
+        export test_level=2
+        export nval_lang=github
+        pytest tests/test_augments.py
+        pytest tests/test_bench.py
+        pytest tests/test_golden.py
         pytest chajda --doctest-modules
 
   docker:

--- a/chajda/tsquery/augments.py
+++ b/chajda/tsquery/augments.py
@@ -1,6 +1,11 @@
 '''
 '''
-
+import os
+import json
+import fasttext
+import fasttext.util
+from annoy import AnnoyIndex
+from collections import namedtuple
 from chajda.tsvector import lemmatize, Config
 from chajda.tsquery.__init__ import to_tsquery
 
@@ -53,31 +58,112 @@ def augments_gensim(lang, word, config=Config(), n=5):
 
     return words
 
-import os
-import fasttext
-import fasttext.util
-from annoy import AnnoyIndex
+
+################################################################################
+# fasttext
+################################################################################
 
 # path used for storing/loading fasttext models and annoy indices
 fasttext_annoy_data_path = os.path.dirname(__file__)
 
+# dictionary used for storing languages as keys, and corresponding loaded fasttext models as values
 fasttext_models = {}
+
+
+def load_fasttext(lang):
+    '''
+    Downloads and loads a fasttext model for a particular language,
+    storing the fasttext model object in the fasttext_models dictionary.
+    Due to the size of fasttext models (>1gb), and the loading time,
+    we do not load all models on program startup.
+    Instead, this function is used to load them lazily as needed.
+    lang: language passed from augments_fasttext
+
+    NOTE:
+    The doctest below has been commented out due to requiring more memory than github actions allows for.
+    # >>> load_fasttext_model('ja') or fasttext_models['ja'] != None
+    # True
+    '''
+
+    # suppress_stdout_stderr() is used for redirecting stdout and stderr when downloading and loading fasttext models.
+    # Without this, stdout and stderr from fasttext causes doctests to fail.
+    with suppress_stdout_stderr():
+
+        # fasttext downloads models to the current directory,
+        # but we want to store the model in chaja/tsquery/fasttext,
+        # so we change the working directory before downloading
+        working_dir = os.getcwd()
+        os.makedirs(f"{fasttext_annoy_data_path}/fasttext", exist_ok=True)
+        os.chdir(f"{fasttext_annoy_data_path}/fasttext")
+
+        # download and load fasttext model
+        fasttext.util.download_model(lang, if_exists='ignore')
+        fasttext_models[lang] = fasttext.load_model(f"cc.{lang}.300.bin")
+
+        # fasttext downloads cc.{lang}.300.bin.gz and then decompresses the .gz file into cc.{lang}.300.bin,
+        # however, we only need cc.{lang}.300.bin,
+        # so we remove unneeded .gz file if exists
+        if os.path.isfile(f"{fasttext_annoy_data_path}/fasttext/cc.{lang}.300.bin.gz"):
+            os.remove(f"{fasttext_annoy_data_path}/fasttext/cc.{lang}.300.bin.gz")
+
+        # change working directory back
+        os.chdir(working_dir)
+
+    # Executing fasttext's get_nearest_neighbor as well as accessing the words in the fasttext model both run
+    # significantly faster after they have been called once,
+    # so we call them once upon loading the model to ensure most efficient runtime for subsequent uses.
+    fasttext_models[lang].get_nearest_neighbors('google', k=5)
+    fasttext_list = []
+    for word in fasttext_models[lang].get_words(on_unicode_error='replace'):
+        fasttext_list.append(word)
+
+
+def destroy_fasttext(lang):
+    '''
+    removes fasttext model from disk and memory
+    '''
+
+    # remove fasttext download from disk
+    if os.path.isfile(f"{fasttext_annoy_data_path}/fasttext/cc.{lang}.300.bin"):
+        os.remove(f"{fasttext_annoy_data_path}/fasttext/cc.{lang}.300.bin")
+
+    # remove fasttext model from memory
+    try:
+        del fasttext_models[lang]
+    except KeyError:
+        pass
+
+
+################################################################################
+# annoy
+################################################################################
+
+# dictionary used for storing language abbreviations as keys,
+# and a namedtuple containing the corresponding annoy index, as well as two json files, as values
 annoy_indices = {}
 
+# dictionaries for storing fasttext model words, and their corresponding indices;
+# fasttext_index_for_word stores fasttext words as keys, and corresponding indices as values;
+# fasttext_word_at_index stores fasttext word indices as keys, and corresponding words as values;
+# both dictionaries are populated by the load_annoy_index function,
+# and subsequently written to json files
+# NOTE:
+# these dictionaries are necessary for using annoy for nearest neighbor query after removing fasttext download
+fasttext_index_for_word = {}
+fasttext_word_at_index = {}
 
-def create_annoy_index_if_needed(lang, word='google', n=5, seed=22):
+
+def load_annoy(lang, word='google', n=5, seed=22, run_destroy_fasttext = True):
     '''
     Checks whether an annoy index has already been created for a specified language.
     Populates an annoy index  with vectors from the fasttext model that corresponds to language,
-    builds the index, saves it to disk. 
-    The annoy index is stored in the annoy_indices dictionary.
-
+    builds the index, saves it to disk.
+    The annoy index is stored in the annoy dictionary.
     lang: language passed from augments_fasttext
-    
+
     NOTE:
     Populating an annoy index with vectors from a fasttext model requires more memory than github actions allows for.
     Therefore, the doctest has been commented out.
-
     # >>> create_annoy_index_if_needed('en') or annoy_indices['en'] != None
     # True
     '''
@@ -85,82 +171,102 @@ def create_annoy_index_if_needed(lang, word='google', n=5, seed=22):
     try:
         annoy_indices[lang]
     except KeyError:
-        annoy_indices[lang] = AnnoyIndex(300, 'angular')
+        annoy_indices[lang] = namedtuple("annoy", ['index', 'index_for_word', 'word_at_index'])
+        annoy_indices[lang].index = AnnoyIndex(300, 'angular')
 
         # if annoy index has not been saved for this language yet,
         # populate annoy index with vectors from corresponding fasttext model
         try:
-            annoy_indices[lang].load(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
+            annoy_indices[lang].index.load(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
 
         # OSError occurs if index is not already saved to disk
         except OSError:
+            # download fasttext model if not already downloaded
+            try:
+                fasttext_models[lang]
+            except KeyError:
+                load_fasttext(lang)
+
             # The annoy library uses a random number genertor when building up the trees for an Annoy Index.
             # In order to ensure that the output is deterministic, we specify the seed value for the random number generator.
-            annoy_indices[lang].set_seed(seed)
+            annoy_indices[lang].index.set_seed(seed)
 
             # Populate annoy index with vectors from corresponding fasttext model
             i = 0
-            for j in fasttext_models[lang].words:
+            for j in fasttext_models[lang].get_words(on_unicode_error='replace'):
                 v = fasttext_models[lang][j]
-                annoy_indices[lang].add_item(i,v)
+                annoy_indices[lang].index.add_item(i,v)
                 i += 1
 
-            # build the trees for the index    
-            annoy_indices[lang].build(10)
+            # build the trees for the index
+            annoy_indices[lang].index.build(10)
 
             # save the index to annoy directory,
             # make the directory if needed
             try:
-                annoy_indices[lang].save(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
+                annoy_indices[lang].index.save(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
             except OSError:
                 os.mkdir(f"{fasttext_annoy_data_path}/annoy")
-                annoy_indices[lang].save(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
+                annoy_indices[lang].index.save(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
+
+            # populate fasttext_index_for_word and fasttext_word_at_index with words from fasttext model dictionary,
+            # as well as indices for each word 
+            i=0
+            for word in fasttext_models[lang].get_words(on_unicode_error='replace'):
+                fasttext_index_for_word[word] = i
+                fasttext_word_at_index[i] = word
+                i += 1
+
+            # write fasttext_index_for_word to json file
+            with open(f"{fasttext_annoy_data_path}/annoy/fasttext_index_for_word_{lang}_lookup.json", "w") as outfile:
+                json.dump(fasttext_index_for_word, outfile)
+
+            # write fasttext_word_at_index to json file
+            with open(f"{fasttext_annoy_data_path}/annoy/fasttext_word_at_index_{lang}_lookup.json", "w") as outfile:
+                json.dump(fasttext_word_at_index, outfile)
+
+            json_index_for_word = open(f"{fasttext_annoy_data_path}/annoy/fasttext_index_for_word_{lang}_lookup.json", "r")
+            annoy_indices[lang].index_for_word = json.load(json_index_for_word)
+
+            json_word_at_index = open(f"{fasttext_annoy_data_path}/annoy/fasttext_word_at_index_{lang}_lookup.json", "r")
+            annoy_indices[lang].word_at_index = json.load(json_word_at_index)
+
+            # remove fasttext model from disk and memory
+            if run_destroy_fasttext:
+                destroy_fasttext(lang)
 
 
-def load_fasttext_model(lang):
+def destroy_annoy(lang, seed=22):
     '''
-    Downloads and loads a fasttext model for a particular language,
-    storing the fasttext model object in the fasttext_models dictionary.
-    Due to the size of fasttext models (>1gb), and the loading time,
-    we do not load all models on program startup.
-    Instead, this function is used to load them lazily as needed. 
-
-    lang: language passed from augments_fasttext
-    
-    NOTE:
-    The doctest below has been commented out due to requiring more memory than github actions allows for.
-
-    # >>> load_fasttext_model('ja') or fasttext_models['ja'] != None
-    # True
+    removes annoy index from disk and memory
     '''
-    working_dir = os.getcwd()
-    # suppress_stdout_stderr() is used for redirecting stdout and stderr when downloading and loading fasttext models.
-    # Without this, stdout and stderr from fasttext causes doctests to fail. 
-    with suppress_stdout_stderr():
 
-        # fasttext downloads models to the current directory,
-        # but we want to store the model in chaja/tsquery/fasttext,
-        # so we change the working directory before downloading
-        try:      
-            os.chdir(f"{fasttext_annoy_data_path}/fasttext")
-        except OSError:
-            os.mkdir(f"{fasttext_annoy_data_path}/fasttext")
-            os.chdir(f"{fasttext_annoy_data_path}/fasttext")
+    # remove annoy index from disk
+    if os.path.isfile(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann"):
+        os.remove(f"{fasttext_annoy_data_path}/annoy/{lang}{seed}.ann")
 
-        # download and load fasttext model
-        fasttext.util.download_model(lang, if_exists='ignore')
-        fasttext_models[lang] = fasttext.load_model(f"cc.{lang}.300.bin")
+    # remove annoy index from memory
+    try:
+        del annoy_indices[lang]
+    except KeyError:
+        pass
 
-        # change working directory back
-        os.chdir(working_dir)
+    # remove json files from disk and memory
+    if os.path.isfile(f"{fasttext_annoy_data_path}/annoy/fasttext_index_for_word_{lang}_lookup.json"):
+        os.remove(f"{fasttext_annoy_data_path}/annoy/fasttext_index_for_word_{lang}_lookup.json")
 
-    # Executing fasttext's get_nearest_neighbor as well as accessing the words in the fasttext model both run
-    # significantly faster after they has been called once,
-    # so we call them once upon loading the model to ensure most efficient runtime for subsequent uses.
-    fasttext_models[lang].get_nearest_neighbors('google', k=5)
-    fasttext_list = []
-    for word in fasttext_models[lang].words:
-        fasttext_list.append(word)
+    try:
+        del annoy_indices[lang].index_for_word
+    except KeyError:
+        pass
+
+    if os.path.isfile(f"{fasttext_annoy_data_path}/annoy/fasttext_word_at_index_{lang}_lookup.json"):
+        os.remove(f"{fasttext_annoy_data_path}/annoy/fasttext_word_at_index_{lang}_lookup.json")
+
+    try:
+        del annoy_indices[lang].word_at_index
+    except KeyError:
+        pass
 
 
 def augments_fasttext(lang, word, config=Config(), n=5, annoy=True):
@@ -185,7 +291,7 @@ def augments_fasttext(lang, word, config=Config(), n=5, annoy=True):
     ['queen', 'kingthe']
     
     NOTE:
-    Populating an annoy index with vectors from a fasttext model requires more memory than github actions allows for.
+    Populating an AnnoyIndex with vectors from a fasttext model requires more memory than github actions allows for.
     Therefore, the doctests involving the annoy library have been commented out below.
 
     # >>> augments_fasttext('en','weapon', n=5)
@@ -205,25 +311,27 @@ def augments_fasttext(lang, word, config=Config(), n=5, annoy=True):
     # >>> augments_fasttext('es','escuela', n=5)
     # ['escuelala', 'academia', 'universidad', 'laescuela']
     '''
-    # download and load the fasttext model if it's not already loaded
-    try:
-        fasttext_models[lang]
-    except KeyError:
-        load_fasttext_model(lang)
-    
+
     # augments_fasttext defaults to using the annoy library to find nearest neighbors,
     # if annoy==False is passed into the function, then the fasttext library will be used.
     if annoy:
 
-        # populate and load annoy index with vectors from fasttext model if not already populated
-        create_annoy_index_if_needed(lang)
+        # populate and load AnnoyIndex with vectors from fasttext model if not already populated
+        load_annoy(lang)
 
         # find the most similar words using annoy library
-        n_nearest_neighbor_indices = annoy_indices[lang].get_nns_by_vector(fasttext_models[lang][word], n)
-        n_nearest_neighbors = [fasttext_models[lang].words[i] for i in n_nearest_neighbor_indices]
+        n_nearest_neighbor_indices = annoy_indices[lang].index.get_nns_by_item(annoy_indices[lang].index_for_word[word], n)
+        n_nearest_neighbors = [ annoy_indices[lang].word_at_index[f"{i}"] for i in n_nearest_neighbor_indices ]
+
         words = ' '.join([ word for word in n_nearest_neighbors ])
 
     else:
+        # download fasttext model if not already downloaded
+        try:
+            fasttext_models[lang]
+        except KeyError:
+            load_fasttext(lang)
+
         # find the most similar words using fasttext library
         topn = fasttext_models[lang].get_nearest_neighbors(word, k=n)
         words = ' '.join([ word for (rank, word) in topn ])
@@ -231,8 +339,9 @@ def augments_fasttext(lang, word, config=Config(), n=5, annoy=True):
     # lemmatize the results so that they'll be in the search document's vocabulary
     words = lemmatize(lang, words, add_positions=False, config=config).split()
     words = list(filter(lambda w: len(w)>1 and w != word, words))[:n]
- 
+
     return words
+
 
 # The following imports as well as suppress_stdout_stderr() are taken from stackoverflow:
 # https://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions

--- a/tests/test_augments.py
+++ b/tests/test_augments.py
@@ -1,0 +1,120 @@
+import pytest
+import os
+
+# the sys import is needed so that we can import from the current project
+import sys
+sys.path.append('.')
+from collections import defaultdict
+from chajda.tsquery.augments import load_annoy, load_fasttext, augments_fasttext, destroy_annoy, destroy_fasttext
+
+# NOTE:
+# the benchmark tests in this file are structured such that an environment variable can be used to specify which languages to test
+
+
+################################################################################
+# global variables
+################################################################################
+
+# default to testing only English if environment variable is misspelled or omitted
+params = defaultdict(lambda: ['en'])
+
+# test_level 0: tests only English
+params['0'] = ['en']
+
+# test_level 1: tests English, Spanish, Korean, and Chinese
+params['1'] = ['en', 'es', 'ko', 'zh']
+
+# test_level 2: Assamese (as), Zazaki (diq), Piedmontese (pms), Walloon (wa)
+# NOTE:
+# populating an annoy index with vectors from even one  major language, e.g. English, Spanish, Chinese, Korean,
+# requires more memory allocation than github actions allows for.
+# For this reason, we use test_level 2, which consists of much smaller fasttext language models,
+# for github actions testing
+params['2'] = ['as', 'diq', 'pms', 'wa']
+
+# test_level 3: tests all languages supported by the spaCy library
+params['3'] = ['af', 'ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'ga', 'gu', 'he', 'hi', 'hr', 'hu', 'hy', 'id', 'is', 'it', 'ja', 'kn', 'ko', 'lb', 'lij', 'lt', 'lv', 'ml', 'mr', 'nb', 'ne', 'nl', 'pl', 'pt', 'ro', 'ru', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'tt', 'uk', 'ur', 'vi', 'xx', 'yo', 'zh']
+
+# test_level 4: tests all languages supported by the fasttext library
+params['4']  = ['af', 'als', 'am', 'an', 'ar', 'arz', 'as', 'ast', 'az', 'azb', 'ba', 'bar', 'bcl', 'be', 'bg', 'bh', 'bn', 'bo', 'bpy', 'br', 'bs', 'ca', 'ce', 'ceb', 'ckb', 'co', 'cs', 'cv', 'cy', 'da', 'de', 'diq', 'dv', 'el', 'eml', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'frr', 'fy', 'ga', 'gd', 'gl', 'gom', 'gu', 'gv', 'he', 'hi', 'hif', 'hr', 'hsb', 'ht', 'hu', 'hy', 'ia', 'id', 'ilo', 'io', 'is', 'it', 'ja', 'jv', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'ky', 'la', 'lb', 'li', 'lmo', 'lt', 'lv', 'mai', 'mg', 'mhr', 'min', 'mk', 'ml', 'mn', 'mr', 'mrj', 'ms', 'mt', 'mwl', 'my', 'myv', 'mzn', 'nah', 'nap', 'nds', 'ne', 'new', 'nl', 'nn', 'no', 'nso', 'oc', 'or', 'os', 'pa', 'pam', 'pfl', 'pl', 'pms', 'pnb', 'ps', 'pt', 'qu', 'rm', 'ro', 'ru', 'sa', 'sah', 'sc', 'scn', 'sco', 'sd', 'sh', 'si', 'sk', 'sl', 'so', 'sq', 'sr', 'su', 'sv', 'sw', 'ta', 'te', 'tg', 'th', 'tk', 'tl', 'tr', 'tt', 'ug', 'uk', 'ur', 'uz', 'vec', 'vi', 'vls', 'vo', 'wa', 'war', 'xmf', 'yi', 'yo', 'zea', 'zh']
+
+# n values to be parametrized
+nval = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+
+# NOTE:
+# for the same reason mentioned above in the test_level 2 comment,
+# we use Walloon as the language for tests parametrized by n-values instead of English when pushing to github,
+# however, the default language is English
+nval_lang = defaultdict(lambda: 'en')
+
+nval_lang['github'] = 'wa'
+
+# all languages will be tested using the word 'google'
+test_word = 'google'
+
+
+################################################################################
+# setup/teardown for test_level parametrized tests
+################################################################################
+
+@pytest.fixture(scope='module', params=params[os.getenv('test_level')])
+def req_param(request):
+    return request.param
+
+@pytest.fixture(scope='module')
+def run_around_tests(req_param):
+    param = req_param
+
+    # setup: preloading fasttext model and annoy index for param language
+    load_fasttext(param)
+
+    # given that test_augments_fasttext requires the fasttext model to be downloaded,
+    # we specify run_destroy_fasttext=False to prevent load_annoy from removing the fasttext download
+    load_annoy(param, run_destroy_fasttext=False)
+
+    # running test
+    yield run_around_tests
+    
+    # teardown
+    destroy_annoy(param)
+    destroy_fasttext(param)
+
+
+################################################################################
+# setup for benchmark tests parametrized by 'n' value
+################################################################################
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_teardown_n(lang=nval_lang[os.getenv('nval_lang')]):
+    # Will be executed before the first test
+    load_fasttext(lang)
+    load_annoy(lang, run_destroy_fasttext=False)
+
+    yield setup_teardown_n
+
+    # Will be executed after the last test
+    destroy_annoy(lang)
+    destroy_fasttext(lang)
+
+
+################################################################################
+# test cases
+################################################################################
+
+# test case using only English language, parametrized on 'n' value with annoy
+@pytest.mark.parametrize('nval', nval)
+def test_augments_n_values_annoy(setup_teardown_n,nval, benchmark):
+    benchmark(augments_fasttext, nval_lang[os.getenv('nval_lang')], test_word, n=nval)
+
+# test case using only English language, parametrized on 'n' value with fasttext
+@pytest.mark.parametrize('nval', nval)
+def test_augments_n_values_fasttext(setup_teardown_n, nval, benchmark):
+    benchmark(augments_fasttext, nval_lang[os.getenv('nval_lang')], test_word, n=nval, annoy=False)
+
+# test case using test_level parameters with annoy
+def test_augments_annoy(run_around_tests, benchmark, req_param):
+    benchmark(augments_fasttext, req_param, test_word)
+
+# test case using test_level parameters with fasttext
+def test_augments_fasttext(run_around_tests, benchmark, req_param):
+    benchmark(augments_fasttext, req_param, test_word, annoy=False)


### PR DESCRIPTION
There are some changes in the `test_augments.py` file that are worth discussing tomorrow morning (e.g. not including English in the params used for github actions), but I thought it best to submit the PR tonight anyways in the event that you have time to glance over it before our meeting.